### PR TITLE
Provide error message along with job status

### DIFF
--- a/__tests__/api/job.spec.js
+++ b/__tests__/api/job.spec.js
@@ -65,24 +65,45 @@ describe('Test job routes', () => {
       })
       .expect(200); // Ok
   });
-
-  test('Job 10 status should be 202 ', async () => {
-    const response = await request(app)
+  test('Job 10 status should be Created', async () => {
+    await request(app)
       .get('/api/v1/job/10/status')
-      .expect(202); // Processing
-    expect(response.body.status).toBe('Processing');
+      .expect(202) // Processing
+      .expect(res => {
+        expect(res.body.status).toBe('Created');
+      });
   });
 
-  test('Job 20 status should be 200 ', async () => {
-    const response = await request(app)
+  test('Job 11 status should be Processing', async () => {
+    await request(app)
+      .get('/api/v1/job/11/status')
+      .expect(202) // Processing
+      .expect(res => {
+        expect(res.body.status).toBe('Processing');
+      });
+  });
+
+  test('Job 20 status should be Completed', async () => {
+    await request(app)
       .get('/api/v1/job/20/status')
-      .expect(200); // Ok
-    expect(response.body.status).toBe('Completed');
+      .expect(200)
+      .expect(res => {
+        expect(res.body.status).toBe('Completed');
+      });
   });
 
-  test('Job 40 status should be 404 ', async () => {
+  test('Job 40 status should be Failed', async () => {
     await request(app)
       .get('/api/v1/job/40/status')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.status).toBe('Failed');
+      });
+  });
+
+  test('Job 50 to not exists', async () => {
+    await request(app)
+      .get('/api/v1/job/50/status')
       .expect(404); // Not Found
   });
 });

--- a/src/libs/db/migrations/20181126160129_add_status_message.js
+++ b/src/libs/db/migrations/20181126160129_add_status_message.js
@@ -1,0 +1,35 @@
+//
+// MyRA
+//
+// Copyright © 2018 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Jason Leach on 2018-11-01.
+//
+
+'use strict';
+
+/* eslint-disable no-unused-vars */
+
+const table = 'job';
+
+exports.up = async knex =>
+  knex.schema.table(table, async t => {
+    t.string('status_message', 128);
+  });
+
+exports.down = async knex =>
+  knex.schema.table(table, async t => {
+    t.dropColumn('status_message');
+  });

--- a/src/libs/db/models/__mocks__/job.js
+++ b/src/libs/db/models/__mocks__/job.js
@@ -22,6 +22,7 @@
 
 'use strict';
 
+import { JOB_STATUS } from '../../../../constants';
 import Model from '../model';
 
 export default class Job extends Model {
@@ -30,20 +31,15 @@ export default class Job extends Model {
   }
 
   static async findById(db, id) {
-    if (Number(id) === 10) return { id: 10 }; // Processing
+    if (Number(id) === 10) return { id: 10, status: JOB_STATUS.CREATED };
+    if (Number(id) === 11) return { id: 11, status: JOB_STATUS.PROCESSING };
     if (Number(id) === 20)
       return {
         id: 20,
         originalFileName: 'hello-file.zip',
         deliveryFileName: 'notExpiredFile',
         token: '123abc',
-      }; // Done
-    if (Number(id) === 30)
-      return {
-        id: 30,
-        originalFileName: 'hello-file.zip',
-        deliveryFileName: 'expiredFile',
-        token: '123abc',
+        status: JOB_STATUS.COMPLETED,
       }; // Done
     if (Number(id) === 21)
       return {
@@ -51,7 +47,22 @@ export default class Job extends Model {
         platform: 'android',
         originalFileName: 'hello-file.zip',
         deliveryFileName: 'notExpiredFile',
+        status: JOB_STATUS.COMPLETED,
       }; // Deployment api test
+    if (Number(id) === 30)
+      return {
+        id: 30,
+        originalFileName: 'hello-file.zip',
+        deliveryFileName: 'expiredFile',
+        token: '123abc',
+        status: JOB_STATUS.COMPLETED,
+      }; // Done
+    if (Number(id) === 40)
+      return {
+        id: 21,
+        platform: 'ios',
+        status: JOB_STATUS.FAILED,
+      };
 
     return undefined;
   }

--- a/src/libs/db/models/job.js
+++ b/src/libs/db/models/job.js
@@ -35,6 +35,7 @@ export default class Job extends Model {
       'deployment_platform',
       'token',
       'status',
+      'status_message',
       'project_id',
     ].map(field => `${this.table}.${field}`);
   }

--- a/src/router/routes/deploy.js
+++ b/src/router/routes/deploy.js
@@ -36,6 +36,7 @@ import request from 'request-promise-native';
 import url from 'url';
 import config from '../../config';
 import DataManager from '../../libs/db';
+import { JOB_STATUS } from '../../constants';
 import shared from '../../libs/shared';
 
 const router = new Router();
@@ -106,7 +107,7 @@ router.post(
         originalFileEtag: signedJob.originalFileEtag,
         deploymentPlatform: deploymentPlatform.toLocaleLowerCase(),
         projectId,
-        status: 'Created',
+        status: JOB_STATUS.CREATED,
       });
 
       logger.info(`Created deployment job with ID ${job.id}`);

--- a/src/router/routes/job.js
+++ b/src/router/routes/job.js
@@ -54,7 +54,7 @@ router.put(
     }
 
     logger.info(`Updating status of job jobId = ${jobId}`);
-
+    console.log(job);
     try {
       await Job.update(
         db,
@@ -63,6 +63,7 @@ router.put(
           deliveryFileName: job.deliveryFileName || null,
           deliveryFileEtag: job.deliveryFileEtag || null,
           status: job.status,
+          statusMessage: job.message || null,
         }
       );
 
@@ -99,6 +100,7 @@ router.get(
 
         return res.status(code).json({
           status: job.status,
+          statusMessage: job.statusMessage,
         });
       }
 
@@ -106,6 +108,7 @@ router.get(
 
       return res.status(200).json({
         status: job.status,
+        statusMessage: job.statusMessage || null,
         url: `${deliveryUrl}?token=${job.token}`,
         durationInSeconds: job.duration,
       });

--- a/src/router/routes/job.js
+++ b/src/router/routes/job.js
@@ -54,7 +54,6 @@ router.put(
     }
 
     logger.info(`Updating status of job jobId = ${jobId}`);
-    console.log(job);
     try {
       await Job.update(
         db,
@@ -90,15 +89,10 @@ router.get(
     }
 
     try {
-      if (job && !job.deliveryFileName) {
+      if (job && (job.status === JOB_STATUS.CREATED || job.status === JOB_STATUS.PROCESSING)) {
         // The request has been accepted for processing,
         // but the processing has not been completed.
-        let code = 200;
-        if (job.status === JOB_STATUS.CREATED || job.status === JOB_STATUS.PROCESSING) {
-          code = 202;
-        }
-
-        return res.status(code).json({
+        return res.status(202).json({
           status: job.status,
           statusMessage: job.statusMessage,
         });

--- a/src/router/routes/job.js
+++ b/src/router/routes/job.js
@@ -92,15 +92,20 @@ router.get(
       if (job && !job.deliveryFileName) {
         // The request has been accepted for processing,
         // but the processing has not been completed.
-        return res.status(202).json({
-          status: JOB_STATUS.PROCESSING,
+        let code = 200;
+        if (job.status === JOB_STATUS.CREATED || job.status === JOB_STATUS.PROCESSING) {
+          code = 202;
+        }
+
+        return res.status(code).json({
+          status: job.status,
         });
       }
 
       const deliveryUrl = url.resolve(config.get('apiUrl'), `/api/v1/delivery/${job.id}`);
 
       return res.status(200).json({
-        status: JOB_STATUS.COMPLETED,
+        status: job.status,
         url: `${deliveryUrl}?token=${job.token}`,
         durationInSeconds: job.duration,
       });

--- a/src/router/routes/sign.js
+++ b/src/router/routes/sign.js
@@ -98,7 +98,7 @@ router.post(
         platform: platform.toLocaleLowerCase(),
         originalFileEtag: etag,
         token: crypto.randomBytes(8).toString('hex'),
-        status: 'Created',
+        status: JOB_STATUS.CREATED,
       });
 
       logger.info(`Created job with ID ${job.id}`);

--- a/src/router/routes/sign.js
+++ b/src/router/routes/sign.js
@@ -30,6 +30,7 @@ import multer from 'multer';
 import request from 'request-promise-native';
 import url from 'url';
 import config from '../../config';
+import { JOB_STATUS } from '../../constants';
 import DataManager from '../../libs/db';
 import shared from '../../libs/shared';
 import { cleanup } from '../../libs/utils';
@@ -117,6 +118,14 @@ router.post(
       if (status !== 'OK') {
         throw errorWithCode(`Unable to send job ${job.id} to agent`, 500);
       }
+
+      await Job.update(
+        db,
+        { id: job.id },
+        {
+          status: JOB_STATUS.PROCESSING,
+        }
+      );
 
       res.status(202).json({ id: job.id }); // Accepted
 


### PR DESCRIPTION
When the job status is reported back by the Agent the status message (if provided) is persistently stored. It is then provided to any clients that request the status of a job.