### PR TITLE
Add check for proper roles

### DIFF
--- a/__tests__/authmware.spec.js
+++ b/__tests__/authmware.spec.js
@@ -1,0 +1,57 @@
+//
+//
+// Copyright © 2018 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Jason Leach on 2018-11-05.
+//
+
+/* eslint-env es6 */
+
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+import { verify } from '../src/libs/authmware';
+
+const path0 = path.join(__dirname, 'fixtures/jwt-decoded-norole-20181105.json');
+const decodedNoRole = JSON.parse(fs.readFileSync(path0, 'utf8'));
+
+const path1 = path.join(__dirname, 'fixtures/jwt-decoded-roleok-20181105.json');
+const decodedWithRole = JSON.parse(fs.readFileSync(path1, 'utf8'));
+
+describe('Test Authentication', () => {
+  test('A JWT without the correct role is not accepted', () => {
+    const fn = (err, user) => {
+      expect(err).toBeDefined();
+      expect(user).toBeNull();
+    };
+
+    verify({}, decodedNoRole, fn);
+  });
+
+  test('A JWT with the correct role is accepted', () => {
+    const fn = (err, user) => {
+      expect(err).toBeNull();
+      expect(user).toBeDefined();
+      expect(user.roles).toBeDefined();
+      expect(user.preferredUsername).toBeDefined();
+      expect(user.givenName).toBeDefined();
+      expect(user.familyName).toBeDefined();
+      expect(user.email).toBeDefined();
+    };
+
+    verify({}, decodedWithRole, fn);
+  });
+});

--- a/__tests__/authmware.spec.js
+++ b/__tests__/authmware.spec.js
@@ -23,22 +23,53 @@
 
 import fs from 'fs';
 import path from 'path';
-import { verify } from '../src/libs/authmware';
+import { isAuthorized, verify } from '../src/libs/authmware';
 
 const path0 = path.join(__dirname, 'fixtures/jwt-decoded-norole-20181105.json');
-const decodedNoRole = JSON.parse(fs.readFileSync(path0, 'utf8'));
+const noRole = JSON.parse(fs.readFileSync(path0, 'utf8'));
 
 const path1 = path.join(__dirname, 'fixtures/jwt-decoded-roleok-20181105.json');
-const decodedWithRole = JSON.parse(fs.readFileSync(path1, 'utf8'));
+const withRole = JSON.parse(fs.readFileSync(path1, 'utf8'));
 
-describe('Test Authentication', () => {
+const path2 = path.join(__dirname, 'fixtures/jwt-decoded-sa-20181107.json');
+const saOk = JSON.parse(fs.readFileSync(path2, 'utf8'));
+
+const path3 = path.join(__dirname, 'fixtures/jwt-decoded-sa-badid-20181107.json');
+const saBadId = JSON.parse(fs.readFileSync(path3, 'utf8'));
+
+const path4 = path.join(__dirname, 'fixtures/jwt-decoded-sa-badname-20181107.json');
+const saBadName = JSON.parse(fs.readFileSync(path4, 'utf8'));
+
+describe('Authentication tests', () => {
+  test('A JWT without the correct role is not accepted', () => {
+    expect(isAuthorized(noRole)).toBeFalsy();
+  });
+
+  test('A JWT with the correct role is accepted', () => {
+    expect(isAuthorized(withRole)).toBeTruthy();
+  });
+
+  test('A service account JWT with valid accepted', () => {
+    expect(isAuthorized(saOk)).toBeTruthy();
+  });
+
+  test('A service account JWT with an invalid ID is rejected', () => {
+    expect(isAuthorized(saBadId)).toBeFalsy();
+  });
+
+  test('A service account JWT with an invalid name is rejected', () => {
+    expect(isAuthorized(saBadName)).toBeFalsy();
+  });
+});
+
+describe('Authentication integration tests', () => {
   test('A JWT without the correct role is not accepted', () => {
     const fn = (err, user) => {
       expect(err).toBeDefined();
       expect(user).toBeNull();
     };
 
-    verify({}, decodedNoRole, fn);
+    verify({}, noRole, fn);
   });
 
   test('A JWT with the correct role is accepted', () => {
@@ -52,6 +83,6 @@ describe('Test Authentication', () => {
       expect(user.email).toBeDefined();
     };
 
-    verify({}, decodedWithRole, fn);
+    verify({}, withRole, fn);
   });
 });

--- a/__tests__/fixtures/jwt-decoded-norole-20181105.json
+++ b/__tests__/fixtures/jwt-decoded-norole-20181105.json
@@ -1,0 +1,21 @@
+{
+  "jti": "0250fdde-fdde-430f-8cbc-e788bb4c25da",
+  "exp": 1544205648,
+  "nbf": 0,
+  "iat": 1544204748,
+  "iss": "https://example.com/auth/realms/myrealm",
+  "aud": "my-client-id",
+  "sub": "3ff0bb0a-9fb8-4461-9994-c89d96e2ac71",
+  "typ": "ID",
+  "azp": "my-client-id",
+  "nonce": "08c56e6aa5dafd17d56495c2c10ce4d3ed8dd4de788bb4c25daea59e62010600",
+  "auth_time": 1544204724,
+  "session_state": "9b77af84-e883-4bb8-9160-122f575a4178",
+  "acr": "0",
+  "roles": ["blarb"],
+  "name": "Jane Doe",
+  "preferred_username": "xxxx\\jdoe",
+  "given_name": "Jane",
+  "family_name": "Doe",
+  "email": "jdoe@example.com"
+}

--- a/__tests__/fixtures/jwt-decoded-roleok-20181105.json
+++ b/__tests__/fixtures/jwt-decoded-roleok-20181105.json
@@ -1,0 +1,21 @@
+{
+  "jti": "0250fdde-fdde-430f-8cbc-e788bb4c25da",
+  "exp": 1544205648,
+  "nbf": 0,
+  "iat": 1544204748,
+  "iss": "https://example.com/auth/realms/myrealm",
+  "aud": "my-client-id",
+  "sub": "3ff0bb0a-9fb8-4461-9994-c89d96e2ac71",
+  "typ": "ID",
+  "azp": "my-client-id",
+  "nonce": "08c56e6aa5dafd17d56495c2c10ce4d3ed8dd4de788bb4c25daea59e62010600",
+  "auth_time": 1544204724,
+  "session_state": "9b77af84-e883-4bb8-9160-122f575a4178",
+  "acr": "0",
+  "roles": ["devhub_sign"],
+  "name": "Jane Doe",
+  "preferred_username": "xxxx\\jdoe",
+  "given_name": "Jane",
+  "family_name": "Doe",
+  "email": "jdoe@example.com"
+}

--- a/__tests__/fixtures/jwt-decoded-sa-20181107.json
+++ b/__tests__/fixtures/jwt-decoded-sa-20181107.json
@@ -1,0 +1,28 @@
+{
+  "jti": "299a5eff-4723-4b7b-9b3d-9b2298fceb3d",
+  "exp": 1544213405,
+  "nbf": 0,
+  "iat": 1544213105,
+  "iss": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub",
+  "aud": "signing-agent",
+  "sub": "cf660e9d-7796-46fb-9659-cb8b67d17a21",
+  "typ": "Bearer",
+  "azp": "signing-agent",
+  "auth_time": 0,
+  "session_state": "1b7f3667-06e6-432f-86bd-81325908b81b",
+  "acr": "1",
+  "allowed-origins": [],
+  "realm_access": {
+    "roles": ["uma_authorization"]
+  },
+  "resource_access": {
+    "account": {
+      "roles": []
+    }
+  },
+  "clientId": "signing-agent",
+  "clientHost": "192.168.0.1",
+  "preferred_username": "service-account-signing-agent",
+  "clientAddress": "192.168.0.1",
+  "email": "service-account-signing-agent@example.com"
+}

--- a/__tests__/fixtures/jwt-decoded-sa-badid-20181107.json
+++ b/__tests__/fixtures/jwt-decoded-sa-badid-20181107.json
@@ -1,0 +1,28 @@
+{
+  "jti": "299a5eff-4723-4b7b-9b3d-9b2298fceb3d",
+  "exp": 1544213405,
+  "nbf": 0,
+  "iat": 1544213105,
+  "iss": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub",
+  "aud": "signing-agent",
+  "sub": "cf660e9d-7796-46fb-9659-cb8b67d17a21",
+  "typ": "Bearer",
+  "azp": "signing-agent-blarb",
+  "auth_time": 0,
+  "session_state": "1b7f3667-06e6-432f-86bd-81325908b81b",
+  "acr": "1",
+  "allowed-origins": [],
+  "realm_access": {
+    "roles": ["uma_authorization"]
+  },
+  "resource_access": {
+    "account": {
+      "roles": []
+    }
+  },
+  "clientId": "signing-agent-blarb",
+  "clientHost": "192.168.0.1",
+  "preferred_username": "service-account-signing-agent",
+  "clientAddress": "192.168.0.1",
+  "email": "service-account-signing-agent@example.com"
+}

--- a/__tests__/fixtures/jwt-decoded-sa-badname-20181107.json
+++ b/__tests__/fixtures/jwt-decoded-sa-badname-20181107.json
@@ -1,0 +1,28 @@
+{
+  "jti": "299a5eff-4723-4b7b-9b3d-9b2298fceb3d",
+  "exp": 1544213405,
+  "nbf": 0,
+  "iat": 1544213105,
+  "iss": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/devhub",
+  "aud": "signing-agent",
+  "sub": "cf660e9d-7796-46fb-9659-cb8b67d17a21",
+  "typ": "Bearer",
+  "azp": "signing-agent",
+  "auth_time": 0,
+  "session_state": "1b7f3667-06e6-432f-86bd-81325908b81b",
+  "acr": "1",
+  "allowed-origins": [],
+  "realm_access": {
+    "roles": ["uma_authorization"]
+  },
+  "resource_access": {
+    "account": {
+      "roles": []
+    }
+  },
+  "clientId": "signing-agent",
+  "clientHost": "192.168.0.1",
+  "preferred_username": "service-account-signing-agent-blarb",
+  "clientAddress": "192.168.0.1",
+  "email": "service-account-signing-agent@example.com"
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,3 +33,8 @@ export const JOB_STATUS = {
 };
 
 export const AC_ROLE = 'devhub_sign';
+
+export const AC_AGENT = {
+  clientId: 'signing-agent',
+  preferredUsername: 'service-account-signing-agent',
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,9 +32,8 @@ export const JOB_STATUS = {
   FAILED: 'Failed',
 };
 
-export const AC_ROLE = 'devhub_sign';
-
-export const AC_AGENT = {
-  clientId: 'signing-agent',
-  preferredUsername: 'service-account-signing-agent',
+export const ACCESS_CONTROL = {
+  USER_ROLE: 'devhub_sign',
+  AGENT_CLIENT_ID: 'signing-agent',
+  AGENT_USER: 'service-account-signing-agent',
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-// eslint-disable-next-line import/prefer-default-export
 export const ENVIRONMENTS = {
   DEVELOPMENT: 'development',
   PRODUCTION: 'production',
@@ -32,3 +31,5 @@ export const JOB_STATUS = {
   COMPLETED: 'Completed',
   FAILED: 'Failed',
 };
+
+export const AC_ROLE = 'devhub_sign';

--- a/src/libs/authmware.js
+++ b/src/libs/authmware.js
@@ -26,13 +26,13 @@ import { getJwtCertificate, logger } from '@bcgov/nodejs-common-utils';
 import passport from 'passport';
 import { ExtractJwt, Strategy as JwtStrategy } from 'passport-jwt';
 import config from '../config';
-import { AC_AGENT, AC_ROLE } from '../constants';
+import { ACCESS_CONTROL } from '../constants';
 
 const isAuthorized = jwtPayload => {
   if (
-    (jwtPayload.azp === AC_AGENT.clientId &&
-      jwtPayload.preferred_username === AC_AGENT.preferredUsername) ||
-    jwtPayload.roles.includes(AC_ROLE)
+    (jwtPayload.azp === ACCESS_CONTROL.AGENT_CLIENT_ID &&
+      jwtPayload.preferred_username === ACCESS_CONTROL.AGENT_USER) ||
+    jwtPayload.roles.includes(ACCESS_CONTROL.USER_ROLE)
   ) {
     return true;
   }

--- a/src/libs/authmware.js
+++ b/src/libs/authmware.js
@@ -26,14 +26,26 @@ import { getJwtCertificate, logger } from '@bcgov/nodejs-common-utils';
 import passport from 'passport';
 import { ExtractJwt, Strategy as JwtStrategy } from 'passport-jwt';
 import config from '../config';
-import { AC_ROLE } from '../constants';
+import { AC_AGENT, AC_ROLE } from '../constants';
+
+const isAuthorized = jwtPayload => {
+  if (
+    (jwtPayload.azp === AC_AGENT.clientId &&
+      jwtPayload.preferred_username === AC_AGENT.preferredUsername) ||
+    jwtPayload.roles.includes(AC_ROLE)
+  ) {
+    return true;
+  }
+
+  return false;
+};
 
 export const verify = (req, jwtPayload, done) => {
   if (jwtPayload) {
-    if (!jwtPayload.roles.includes(AC_ROLE)) {
-      console.log(jwtPayload.roles);
+    if (!isAuthorized(jwtPayload)) {
       const err = new Error('You do not have the proper role for signing');
       err.code = 401;
+
       return done(err, null);
     }
 

--- a/src/libs/authmware.js
+++ b/src/libs/authmware.js
@@ -28,11 +28,11 @@ import { ExtractJwt, Strategy as JwtStrategy } from 'passport-jwt';
 import config from '../config';
 import { ACCESS_CONTROL } from '../constants';
 
-const isAuthorized = jwtPayload => {
+export const isAuthorized = jwtPayload => {
   if (
     (jwtPayload.azp === ACCESS_CONTROL.AGENT_CLIENT_ID &&
       jwtPayload.preferred_username === ACCESS_CONTROL.AGENT_USER) ||
-    jwtPayload.roles.includes(ACCESS_CONTROL.USER_ROLE)
+    (jwtPayload.roles && jwtPayload.roles.includes(ACCESS_CONTROL.USER_ROLE))
   ) {
     return true;
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,10 +39,10 @@ const corsOptions = {
 export const router = app => {
   app.use(cors(corsOptions));
   app.use('/api/v1/ehlo', ehlo); // probes
-  app.use('/api/v1/delivery', delivery); // secured by shared secret
   // Any routes following the authentication middleware line below
   // will require authentication.
   app.use(passport.authenticate('jwt', { session: false }));
+  app.use('/api/v1/delivery', delivery); // secured by shared secret
   app.use('/api/v1/sign', sign);
   app.use('/api/v1/job', job);
   app.use('/api/v1/deploy', deploy);


### PR DESCRIPTION
Ensure that all users have the proper role before accepting signing jobs. This PR also cleans up the error response when authentication fails and passes some useful user properties on when authentication succeeds.